### PR TITLE
Configurar la clase principal para el Exec Maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.8</java.version>
+		<start-class>main.LoadUsers</start-class>
 	</properties>
 
 	<dependencies>
@@ -134,7 +135,7 @@
 						<!-- automatically creates the classpath using all project dependencies, 
 							also adding the project build directory -->
 						<classpath />
-						<mainClass>main.Main</mainClass>
+						<mainClass>main.LoadUsers</mainClass>
 						<arguments>
 							<argument>load</argument>
 							<argument>src/test/resources/agents.xlsx</argument>


### PR DESCRIPTION
Permite lanzar el proyecto desde Maven ejecutando:

	mvn exec:java
	mvn exec:java -Dexec.args="load src/test/resources/agents.xlsx"

Ver también: Issue #14